### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,15 +77,15 @@
     "esnext": true
   },
   "dependencies": {
+    "babel-polyfill": "^6.8.0",
     "bluebird": "^3.3.5",
     "co": "^4.6.0",
     "fs-promise": "^0.5.0",
     "lodash": "^4.8.2",
     "minimist": "^1.2.0",
     "node-cache": "^3.2.1",
-    "node-uuid": "^1.4.7",
     "prettyjson": "^1.1.3",
-    "babel-polyfill": "^6.8.0"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",

--- a/src/log-stream.js
+++ b/src/log-stream.js
@@ -4,7 +4,7 @@ import assert       from 'assert';
 import net          from 'net';
 import _            from 'lodash';
 import EventEmitter from 'events';
-import uuid         from 'node-uuid';
+import uuid         from 'uuid';
 import jsonEnable   from './json-socket';
 
 export default class LogStream extends EventEmitter {

--- a/src/logger.js
+++ b/src/logger.js
@@ -6,7 +6,7 @@ import net          from 'net';
 import { inspect }  from 'util';
 import Promise      from 'bluebird';
 import NodeCache    from 'node-cache';
-import uuid         from 'node-uuid';
+import uuid         from 'uuid';
 import jsonEnable   from './json-socket';
 
 let promiseCache = new NodeCache( {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.